### PR TITLE
fix: add missing migration for contig constraints from v0.2.0

### DIFF
--- a/bento_reference_service/sql/migrate_v0_5.sql
+++ b/bento_reference_service/sql/migrate_v0_5.sql
@@ -1,0 +1,14 @@
+-- Run these commands before migrating to v0.5.x
+
+-- In the past, we missed some constraint updates. They should have been executed for version 0.2.0.
+
+ALTER TABLE genome_contigs DROP CONSTRAINT IF EXISTS genome_contigs_md5_checksum_key;
+ALTER TABLE genome_contigs DROP CONSTRAINT IF EXISTS genome_contigs_ga4gh_checksum_key;
+
+-- Hacky version of ADD UNIQUE IF NOT EXISTS for md5_checksum
+ALTER TABLE genome_contigs DROP CONSTRAINT IF EXISTS genome_contigs_genome_id_md5_checksum_key;
+ALTER TABLE genome_contigs ADD UNIQUE (genome_id, md5_checksum);
+
+-- Hacky version of ADD UNIQUE IF NOT EXISTS for ga4gh_checksum
+ALTER TABLE genome_contigs DROP CONSTRAINT IF EXISTS genome_contigs_genome_id_ga4gh_checksum_key;
+ALTER TABLE genome_contigs ADD UNIQUE (genome_id, ga4gh_checksum);


### PR DESCRIPTION
@v-rocheleau these SQL statements should hopefully cleanup the old constraints and add new genome ID-specific ones.